### PR TITLE
Add Accordion component, condense README component list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,25 +42,14 @@ Production examples of this project in action:
 
 ## Pre-built Components
 
-Ready-to-use interactive components that can be dropped into any section.
+Ready-to-use, interactive components with ARIA compliance and theme editor integration.
 
-### Tabs
-Animated tab panels with keyboard navigation, ARIA compliance, and GSAP-powered transitions.
-
-- Source: [`_scripts/components/tabs.ts`](_scripts/components/tabs.ts)
-- Snippets: [`snippets/tabs-tab.liquid`](snippets/tabs-tab.liquid), [`snippets/tabs-tabpanel.liquid`](snippets/tabs-tabpanel.liquid)
-
-### Drawer
-Accessible slide-in drawer with focus trap, optional backdrop, and breakpoint-aware auto-close.
-
-- Source: [`_scripts/components/drawer/index.ts`](_scripts/components/drawer/index.ts)
-- Snippet: [`snippets/drawer.liquid`](snippets/drawer.liquid)
-
-### Quantity Adjuster
-Quantity input component with increment/decrement buttons, validation, and configurable min/max bounds.
-
-- Source: [`_scripts/components/quantityAdjuster.ts`](_scripts/components/quantityAdjuster.ts)
-- Snippet: [`snippets/quantity-adjuster.liquid`](snippets/quantity-adjuster.liquid)
+| Component | Description | Source | Snippets |
+|---|---|---|---|
+| Tabs | Animated tab panels with keyboard navigation and GSAP-powered transitions. | [`tabs.ts`](_scripts/components/tabs.ts) | [`tabs-tab.liquid`](snippets/tabs-tab.liquid), [`tabs-tabpanel.liquid`](snippets/tabs-tabpanel.liquid) |
+| Drawer | Slide-in drawer with focus trap, optional backdrop, and breakpoint-aware auto-close. | [`drawer/index.ts`](_scripts/components/drawer/index.ts) | [`drawer.liquid`](snippets/drawer.liquid) |
+| Accordion | Collapsible content panels with animated expand/collapse, single or multi-open modes. | [`accordion.ts`](_scripts/components/accordion.ts), [`accordionItem.ts`](_scripts/components/accordionItem.ts) | [`accordion-item.liquid`](snippets/accordion-item.liquid) |
+| Quantity Adjuster | Numeric input component with increment/decrement buttons, validation, and configurable min/max bounds. | [`quantityAdjuster.ts`](_scripts/components/quantityAdjuster.ts) | [`quantity-adjuster.liquid`](snippets/quantity-adjuster.liquid) |
 
 ## Project Structure
 

--- a/_scripts/components/accordion.ts
+++ b/_scripts/components/accordion.ts
@@ -1,0 +1,63 @@
+import BaseComponent from '@/components/base'
+import AccordionItem from '@/components/accordionItem'
+
+const classes = {
+  isActive: 'is-active'
+}
+
+export default class Accordion extends BaseComponent {
+  static TYPE = 'accordion'
+
+  #activeItems: AccordionItem[] // Private field so that doComponentCleanup can't access
+  #multi: boolean
+
+  items: AccordionItem[]
+
+  constructor(el: HTMLElement) {
+    super(el)
+
+    this.#activeItems = []
+    this.#multi = this.el.dataset.multi === 'true'
+
+    this.items = this.qsa(AccordionItem.SELECTOR).map(el => {
+      return new AccordionItem(el, {
+        onOpen: (item: AccordionItem) => this.onItemOpen(item),
+        onClose: (item: AccordionItem) => this.onItemClose(item)
+      })
+    })
+  }
+
+  #syncActiveClass() {
+    this.el.classList.toggle(classes.isActive, this.#activeItems.length > 0)
+  }
+
+  changeToItem(to: AccordionItem) {
+    if (!this.items.includes(to)) return
+
+    to.open()
+  }
+
+  onItemOpen(item: AccordionItem) {
+    if (!this.#multi) {
+      for (const other of [...this.#activeItems]) {
+        if (other !== item) other.close()
+      }
+    }
+
+    // If they clicked an anchor link, close the other items and then follow the link
+    // but don't change the active items
+    if (item.isAnchor) return
+
+    if (!this.#activeItems.includes(item)) {
+      this.#activeItems.push(item)
+    }
+
+    this.#syncActiveClass()
+  }
+
+  onItemClose(item: AccordionItem) {
+    this.#activeItems = this.#activeItems.filter(_itm => _itm !== item)
+
+    this.#syncActiveClass()
+  }
+}

--- a/_scripts/components/accordionItem.ts
+++ b/_scripts/components/accordionItem.ts
@@ -1,0 +1,140 @@
+import { getUUID } from '@/core/utils'
+import { setAriaState } from '@/core/utils/a11y'
+import gsap, { slideDown, slideUp } from '@/core/gsap'
+
+import BaseComponent from '@/components/base'
+
+interface AccordionItemOptions {
+  onOpen?: (instance: AccordionItem) => void
+  onClose?: (instance: AccordionItem) => void
+}
+
+const selectors = {
+  header: '[data-header]',
+  body: '[data-body]'
+}
+
+export default class AccordionItem extends BaseComponent {
+  static TYPE = 'accordion-item'
+
+  settings: AccordionItemOptions
+  header: HTMLElement
+  body: HTMLElement
+
+  #isAnchor: boolean
+
+  constructor(el: HTMLElement, options: AccordionItemOptions = {}) {
+    super(el)
+
+    this.settings = {
+      ...options
+    }
+
+    this.header = this.qsRequired(selectors.header)
+    this.body = this.qsRequired(selectors.body)
+
+    this.#isAnchor = this.header instanceof HTMLAnchorElement
+
+    const id = `${AccordionItem.TYPE}-${getUUID()}`
+
+    this.header.id = `${id}-header`
+    this.body.id = `${id}-body`
+
+    this.body.setAttribute('aria-labelledby', this.header.id)
+    this.body.hidden = true // Default Closed
+
+    if (!this.#isAnchor) {
+      this.header.setAttribute('aria-controls', this.body.id)
+      setAriaState(this.header, 'aria-expanded', false)
+    }
+
+    this.header.addEventListener('click', this.onHeaderClick.bind(this))
+  }
+
+  destroy() {
+    gsap.killTweensOf(this.body)
+
+    super.destroy()
+  }
+
+  get isAnchor() {
+    return this.#isAnchor
+  }
+
+  get isOpen() {
+    return this.header.getAttribute('aria-expanded') === 'true'
+  }
+
+  set isOpen(value: boolean) {
+    setAriaState(this.header, 'aria-expanded', value)
+  }
+
+  open() {
+    if (this.isOpen) return
+    
+    slideDown(this.body, {
+      onStart: () => {
+        this.isOpen = true
+        this.body.hidden = false
+      },
+      onInterrupt: () => {
+        this.isOpen = false
+        this.body.hidden = true
+      }
+    })
+
+    this.settings.onOpen?.(this)
+  }
+
+  close() {
+    if (!this.isOpen) return
+    
+    slideUp(this.body, {
+      onStart: () => {
+        this.isOpen = false
+      },
+      onInterrupt: () => {
+        this.isOpen = true
+      },
+      onComplete: () => {
+        this.body.hidden = true
+      }
+    })
+
+    this.settings.onClose?.(this)
+  }  
+
+  toggle() {
+    this.isOpen ? this.close() : this.open()
+  }
+
+  onHeaderClick(e: MouseEvent) {
+    if (this.#isAnchor) {
+      // Anchor headers navigate away and have no expanded state, but should still fire onOpen
+      // so a parent can react to the change.
+      this.settings.onOpen?.(this)
+      return
+    }
+
+    e.preventDefault()
+
+    this.toggle()
+  }
+
+  // Theme editor events
+  onSelfBlockSelect() {
+    if (this.#isAnchor) return
+
+    this.open()
+  }
+
+  onSelfBlockDeselect() {
+    this.close()
+  }
+
+  onChildBlockSelect() {
+    if (this.#isAnchor) return
+    
+    this.open()
+  }  
+}

--- a/_scripts/components/tabs.ts
+++ b/_scripts/components/tabs.ts
@@ -48,13 +48,14 @@ export default class Tabs extends BaseComponent {
   static TYPE = 'tabs'
 
   #transitionTl: gsap.core.Timeline | null
+  #orientationVertical: boolean
+  
   settings: TabsSettings
   tablist: HTMLElement
   tabs: HTMLElement[]
   tabpanelsWrapper: HTMLElement
   tabpanels: HTMLElement[]
   currentTab: HTMLElement
-  orientationVertical: boolean
 
   constructor(el: HTMLElement, options: TabsOptions = {}) {
     super(el)
@@ -79,7 +80,7 @@ export default class Tabs extends BaseComponent {
     const selectedTab = this.tabs.find(tab => tab.getAttribute('aria-selected') === 'true')
 
     this.currentTab = selectedTab ?? this.tabs[0]
-    this.orientationVertical = this.tablist.getAttribute('aria-orientation') === 'vertical'
+    this.#orientationVertical = this.tablist.getAttribute('aria-orientation') === 'vertical'
 
     this.onTabClick = this.onTabClick.bind(this)
     this.onTablistKeyDown = this.onTablistKeyDown.bind(this)
@@ -227,10 +228,10 @@ export default class Tabs extends BaseComponent {
     const currentTabIndex = this.tabs.indexOf(this.currentTab)
  
     switch (e.key) {
-      case this.orientationVertical ? ARROW_DOWN_KEY : ARROW_RIGHT_KEY:
+      case this.#orientationVertical ? ARROW_DOWN_KEY : ARROW_RIGHT_KEY:
         newIndex = (currentTabIndex + 1) % this.tabs.length
         break
-      case this.orientationVertical ? ARROW_UP_KEY : ARROW_LEFT_KEY:
+      case this.#orientationVertical ? ARROW_UP_KEY : ARROW_LEFT_KEY:
         newIndex = (currentTabIndex - 1 + this.tabs.length) % this.tabs.length
         break
       case HOME_KEY:

--- a/_styles/app.css
+++ b/_styles/app.css
@@ -250,3 +250,4 @@ img.lazy-image {
 @import './components/_drawer.css';
 @import './components/_policy.css';
 @import './components/_product-card.css';
+@import './components/_accordion.css';

--- a/_styles/components/_accordion.css
+++ b/_styles/components/_accordion.css
@@ -1,0 +1,43 @@
+.accordion {
+  /* &[data-multi="true"] {
+
+  } */
+}
+
+
+.accordion-item {
+  @apply border-b border-grey;
+
+  /* Use this if you need to style inactive items when multi is not enabled */
+  /* @apply transition-opacity duration-400; */
+
+  /* .accordion:not([data-multi="true"]).is-active &:not(:has([aria-expanded="true"])) {
+    @apply opacity-50;
+  } */
+}
+
+.accordion-item__header {
+  @apply relative flex py-3 leading-none;
+  @apply w-full text-left; /* This is needed because we're using a button element.  If we change the markup, re-visit this */
+
+  padding-right: 1.5rem;
+
+  svg {
+    @apply absolute right-0 top-3.5 h-auto transition-transform duration-400;
+    width: 0.8rem;
+  }
+
+  &[aria-expanded="true"] {
+    svg {
+      transform: rotate(135deg);
+    }
+  }
+}
+
+.accordion-item__body {
+  @apply overflow-hidden; 
+}
+
+.accordion-item__body-inner {
+  @apply pb-3; /* Match the padding-bottom of the header */
+}

--- a/_styles/core/_buttons.css
+++ b/_styles/core/_buttons.css
@@ -1,3 +1,7 @@
+button:not([disabled]) {
+  @apply cursor-pointer;
+}
+
 button[disabled] {
   @apply cursor-not-allowed;
 }

--- a/assets/app.bundle.css
+++ b/assets/app.bundle.css
@@ -24,6 +24,7 @@
       --tw-translate-x: 0;
       --tw-translate-y: 0;
       --tw-translate-z: 0;
+      --tw-duration: initial;
     }
   }
 }
@@ -1149,6 +1150,10 @@ table tfoot tr:first-child td {
   border-top-width: 1px;
 }
 
+button:not([disabled]) {
+  cursor: pointer;
+}
+
 button[disabled] {
   cursor: not-allowed;
 }
@@ -2119,6 +2124,48 @@ header.header nav a[aria-current="page"] {
   transition-timing-function: ease-in-out;
 }
 
+.accordion-item {
+  border-bottom-style: var(--tw-border-style);
+  border-bottom-width: 1px;
+  border-color: var(--color-grey);
+}
+
+.accordion-item__header {
+  padding-block: calc(var(--spacing) * 3);
+  --tw-leading: 1;
+  text-align: left;
+  width: 100%;
+  padding-right: 1.5rem;
+  line-height: 1;
+  display: flex;
+  position: relative;
+}
+
+.accordion-item__header svg {
+  top: calc(var(--spacing) * 3.5);
+  right: calc(var(--spacing) * 0);
+  height: auto;
+  transition-property: transform, translate, scale, rotate;
+  transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+  transition-duration: var(--tw-duration, var(--default-transition-duration));
+  --tw-duration: .4s;
+  width: .8rem;
+  transition-duration: .4s;
+  position: absolute;
+}
+
+.accordion-item__header[aria-expanded="true"] svg {
+  transform: rotate(135deg);
+}
+
+.accordion-item__body {
+  overflow: hidden;
+}
+
+.accordion-item__body-inner {
+  padding-bottom: calc(var(--spacing) * 3);
+}
+
 @property --tw-border-style {
   syntax: "*";
   inherits: false;
@@ -2235,4 +2282,9 @@ header.header nav a[aria-current="page"] {
   syntax: "*";
   inherits: false;
   initial-value: 0;
+}
+
+@property --tw-duration {
+  syntax: "*";
+  inherits: false
 }

--- a/snippets/accordion-item.liquid
+++ b/snippets/accordion-item.liquid
@@ -1,0 +1,58 @@
+{% doc %}
+  Accordion Item
+  --------------------------------
+
+  @param {string} title - The title of the accordion item
+  @param {string} [title_link] - The link of the title - if provided, the title will be a link instead of a button
+  @param {string} [content] - The content of the accordion item
+  @param {string} [attributes] - The attributes of the accordion item
+  @param {string} [classes] - The classes of the accordion item
+  @param {object} [block] - The block of the accordion item
+
+  @example
+    {% render 'accordion-item',
+              title: 'Accordion Item Title',
+              content: '<p>Accordion Item Content</p>'
+              block: block
+    %}
+{% enddoc %}
+
+<div
+  class="accordion-item {{ classes }}"
+  data-component="accordion-item"
+  {% if block %}
+    data-block-id="{{ block.id }}"
+    {{ block.shopify_attributes }}
+  {% endif %}
+  {{ attributes }}
+>
+  {% if title_link %}
+    <a
+      class="accordion-item__header"
+      href="{{ title_link }}"
+      data-header
+    >
+      <span>{{ title }}</span>
+    </a>
+  {% else %}
+    <button
+      class="accordion-item__header"
+      type="button"
+      data-header
+    >  
+      <span>{{ title }}</span>
+
+      {{- 'icon-plus.svg' | inline_asset_content -}}      
+    </button>    
+  {% endif %}
+
+  <div
+    class="accordion-item__body"
+    hidden
+    data-body
+  >
+    <div class="accordion-item__body-inner">
+      {{ content }}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
  - New Accordion/AccordionItem components with animated expand/collapse, single or multi-open modes, and ARIA-compliant expanded state
  - Add accordion-item.liquid snippet and _accordion.css styles
  - Make Tabs#orientationVertical a private field
  - Add cursor-pointer to enabled buttons
  - Condense README Pre-built Components section into a table